### PR TITLE
Improve behavior in degenerate cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,43 +19,50 @@ There is an extremely simple example program in the [src](https://github.com/Chi
 
 should output something like
 
-    Sched policy is SCHED_FIFO
-    Sched priority is 46/47
+``` text
+Sched policy is SCHED_FIFO
+Sched priority is 46/47
 
-    Epoch Time is 1511553574 seconds
+Status from clock_getres before init is -1 and errno is 45
 
-    Performing some math operations (sum) ...
-    Done. (result is: sum = 1.64493)
-    Elapsed Time = 7.327930e-01 s
+Epoch Time is 1593677616 seconds
 
-    Wait 2 seconds ...
-    Done waiting.
-    Elapsed Time = 2.000097e+00 s
+Resolution of realtime clock: tv_sec 0 tv_nsec 1
+Resolution of monotonic clock: tv_sec 0 tv_nsec 1
 
-    Interval timer with step size of 0.0005 seconds ...
-    iteration 0 >>> waited 6.320000e-04 seconds
-    iteration 1 >>> waited 5.150000e-04 seconds
-    iteration 2 >>> waited 4.670000e-04 seconds
-    iteration 3 >>> waited 5.030000e-04 seconds
-    iteration 4 >>> waited 5.330000e-04 seconds
-    iteration 5 >>> waited 4.960000e-04 seconds
-    iteration 6 >>> waited 4.680000e-04 seconds
-    iteration 7 >>> waited 5.040000e-04 seconds
-    iteration 8 >>> waited 5.310000e-04 seconds
-    iteration 9 >>> waited 4.960000e-04 seconds
-    iteration 10 >>> waited 4.690000e-04 seconds
-    iteration 11 >>> waited 5.360000e-04 seconds
-    iteration 12 >>> waited 4.660000e-04 seconds
-    iteration 13 >>> waited 4.690000e-04 seconds
-    iteration 14 >>> waited 5.350000e-04 seconds
-    iteration 15 >>> waited 5.290000e-04 seconds
-    iteration 16 >>> waited 4.640000e-04 seconds
-    iteration 17 >>> waited 5.040000e-04 seconds
-    iteration 18 >>> waited 5.330000e-04 seconds
-    iteration 19 >>> waited 4.940000e-04 seconds
-    Finished interval timer.
+Performing some math operations (sum) ...
+Done. (result is: sum = 1.64493)
+Elapsed Time = 8.574453e-01 s
 
-    Epoch Time is 1511553577 seconds
+Wait 2 seconds ...
+Done waiting.
+Elapsed Time = 2.000412e+00 s
+
+Interval timer with step size of 0.0005 seconds ...
+iteration 0 >>> waited 5.876090e-04 seconds
+iteration 1 >>> waited 5.887230e-04 seconds
+iteration 2 >>> waited 4.898970e-04 seconds
+iteration 3 >>> waited 4.884590e-04 seconds
+iteration 4 >>> waited 5.181490e-04 seconds
+iteration 5 >>> waited 4.976460e-04 seconds
+iteration 6 >>> waited 4.704730e-04 seconds
+iteration 7 >>> waited 5.430580e-04 seconds
+iteration 8 >>> waited 4.815320e-04 seconds
+iteration 9 >>> waited 4.065470e-04 seconds
+iteration 10 >>> waited 5.681740e-04 seconds
+iteration 11 >>> waited 5.301990e-04 seconds
+iteration 12 >>> waited 4.931940e-04 seconds
+iteration 13 >>> waited 4.469870e-04 seconds
+iteration 14 >>> waited 5.583800e-04 seconds
+iteration 15 >>> waited 4.978350e-04 seconds
+iteration 16 >>> waited 4.981900e-04 seconds
+iteration 17 >>> waited 5.003510e-04 seconds
+iteration 18 >>> waited 5.005460e-04 seconds
+iteration 19 >>> waited 4.995940e-04 seconds
+Finished interval timer.
+
+Epoch Time is 1593677619 seconds
+```
 
 Note that in this code example, scheduling is applied to a high priority so that the timer performs reliably.
 

--- a/src/timing_test.c
+++ b/src/timing_test.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <unistd.h>
 
+#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
@@ -33,9 +34,14 @@ int main() {
 
     /* timing examples */
     int64_t epoch;
-    struct timespec before, after;
+    int status;
+    struct timespec res, before, after;
     double sum, elapsed, waittime;
     unsigned u;
+    
+    /* using clock_getres before initializing produces an intelligible error */
+    status = clock_getres(CLOCK_MONOTONIC, &res);
+    printf("\nStatus from clock_getres before init is %d and errno is %d\n", status, errno);
 
     /* initialize mach timing */
     timing_mach_init();
@@ -44,6 +50,16 @@ int main() {
     clock_gettime(CLOCK_REALTIME, &before);
     epoch = (int64_t) before.tv_sec;
     printf("\nEpoch Time is %" PRId64 " seconds\n", epoch);
+    
+    /* get clock resolution */
+    clock_getres(CLOCK_REALTIME, &res);
+    printf("\nResolution of realtime clock: tv_sec %ld tv_nsec %ld", res.tv_sec, res.tv_nsec);
+    clock_getres(CLOCK_MONOTONIC, &res);
+    printf("\nResolution of monotonic clock: tv_sec %ld tv_nsec %ld\n", res.tv_sec, res.tv_nsec);
+    
+    /* null pointer should not cause an error */
+    clock_getres(CLOCK_MONOTONIC, NULL);
+    clock_gettime(CLOCK_MONOTONIC, NULL);
 
     /* time something */
     printf("\nPerforming some math operations (sum) ...\n");


### PR DESCRIPTION
I'm writing some code that needs to support time related functions on MacOS prior to 10.12 and came across this repo, and found it to be a helpful resource. Thanks for making this!

I also noticed a few places where it doesn't quite conform to the POSIX specification, specifically in degenerate cases such as calling clock_getres or clock_gettime with a null pointer, so I thought I'd take a few minutes to improve behavior in these cases.

The documentation for clock_getres says that calling it with a null timespec pointer should cause it to just not provide the information. The implementation prior to this PR would try to access the null pointer if passing one to either of these functions. (I am assuming that the same principle extends to clock_gettime. Certainly any handling would be an improvement over the potential null pointer access it had before, though.)

https://man7.org/linux/man-pages/man2/clock_gettime.2.html

> The function clock_getres() finds the resolution (precision) of the specified clock clockid, and, if res is non-NULL, stores it in the struct timespec pointed to by res.

This PR also changes the behavior of clock_getres to return -1 and set errno to a reasonable value (ENOTSUP, _The operation is not supported by the dynamic POSIX clock device specified._) if calling it before initializing, since otherwise calling clock_getres without initializing may lead to a division by zero.